### PR TITLE
feat: backwards compatible change of content key

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The following is an example of a feed file:
         version: '1.0.1',
         file: 'my-module-1/main.css',
         // bundled css content with any @import statements inlined
-        content: '/* ... */'
+        source: '/* ... */'
     }
 ]
 ```

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const { EOL } = require('os');
 
 module.exports = async function reader(feeds = []) {
     assert(
@@ -26,5 +27,5 @@ module.exports = async function reader(feeds = []) {
     // backwards compatible refactor to `.source` from `.content`
     return Array.from(feedMap.values())
         .map(feed => (feed.source || feed.content).trim())
-        .join('\n\n');
+        .join(EOL + EOL);
 };

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -22,6 +22,9 @@ module.exports = async function reader(feeds = []) {
         feedMap.delete(feed.id);
         feedMap.set(feed.id, feed);
     });
-    const dedupedFeeds = Array.from(feedMap.values());
-    return dedupedFeeds.map(feed => feed.content.trim()).join('\n\n');
+
+    // backwards compatible refactor to `.source` from `.content`
+    return Array.from(feedMap.values())
+        .map(feed => (feed.source || feed.content).trim())
+        .join('\n\n');
 };

--- a/test/__snapshots__/reader.test.js.snap
+++ b/test/__snapshots__/reader.test.js.snap
@@ -8,4 +8,4 @@ exports[`reader([]): throws on empty array 1`] = `"Expected at least 1 feed to b
 
 exports[`reader([1,2,3]): throws on array containing non feed items 1`] = `"Expected every feed to be an array. Instead got \\"1, 2, 3\\""`;
 
-exports[`reader(123): throws on non stream or array input 1`] = `"Expected at least 1 feed to be given. Instead got \\"undefined\\""`;
+exports[`reader(123): throws on non array input 1`] = `"Expected at least 1 feed to be given. Instead got \\"undefined\\""`;

--- a/test/reader.test.js
+++ b/test/reader.test.js
@@ -16,7 +16,19 @@ test('reader(feeds) single feed', async () => {
     expect(result).toContain('my-module-1/main.css');
 });
 
-test('reader([stream1, stream2]) mulitple feedStreams merged', async () => {
+test('reader(feeds) support for legacy .content field is maintained', async () => {
+    expect.assertions(1);
+    const sink = new SinkFs({
+        path: path.join(__dirname, './test-assets'),
+    });
+    const feed = JSON.parse(await sink.get('legacy.json'));
+
+    const result = await reader([feed]);
+
+    expect(result).toContain('my-module-1/main.css');
+});
+
+test('reader([feed1, feed2]) mulitple feeds merged', async () => {
     expect.assertions(4);
     const sink = new SinkFs({
         path: path.join(__dirname, './test-assets'),
@@ -54,7 +66,7 @@ test('reader(): throws on no input', async () => {
     }
 });
 
-test('reader(123): throws on non stream or array input', async () => {
+test('reader(123): throws on non array input', async () => {
     expect.assertions(1);
     try {
         await reader(123);

--- a/test/test-assets/b.json
+++ b/test/test-assets/b.json
@@ -1,11 +1,10 @@
 [
-    {
-        "id":
-            "0791418bc4d8ce9e0315f5a23b729fd1fc77df0130b0336b3380d1b4f47c3855",
-        "name": "my-module-3",
-        "version": "1.0.1",
-        "file": "my-module-3/css/main.css",
-        "content":
-            "/* my-module-3/main.css */\n\n/* my-module-3/dep.css */\n\n/* dep/main.css */\n"
-    }
+  {
+    "id": "0791418bc4d8ce9e0315f5a23b729fd1fc77df0130b0336b3380d1b4f47c3855",
+    "name": "my-module-3",
+    "version": "1.0.1",
+    "file": "my-module-3/css/main.css",
+    "source":
+      "/* my-module-3/main.css */\n\n/* my-module-3/dep.css */\n\n/* dep/main.css */\n"
+  }
 ]

--- a/test/test-assets/c.json
+++ b/test/test-assets/c.json
@@ -1,18 +1,16 @@
 [
-    {
-        "id":
-            "4f32a8e1c6cf6e5885241f3ea5fee583560b2dfde38b21ec3f9781c91d58f42e",
-        "name": "my-module-1",
-        "version": "1.0.1",
-        "file": "my-module-1/main.css",
-        "content": "/* my-module-1/main.css */\n"
-    },
-    {
-        "id":
-            "1820708872350aef30523aef4e3516172280ff75be7f0e419b104de43eef0a69",
-        "name": "my-module-2",
-        "version": "1.0.1",
-        "file": "my-module-2/css/main.css",
-        "content": "/* my-module-2/main.css */\n"
-    }
+  {
+    "id": "4f32a8e1c6cf6e5885241f3ea5fee583560b2dfde38b21ec3f9781c91d58f42e",
+    "name": "my-module-1",
+    "version": "1.0.1",
+    "file": "my-module-1/main.css",
+    "source": "/* my-module-1/main.css */\n"
+  },
+  {
+    "id": "1820708872350aef30523aef4e3516172280ff75be7f0e419b104de43eef0a69",
+    "name": "my-module-2",
+    "version": "1.0.1",
+    "file": "my-module-2/css/main.css",
+    "source": "/* my-module-2/main.css */\n"
+  }
 ]

--- a/test/test-assets/d.json
+++ b/test/test-assets/d.json
@@ -1,10 +1,9 @@
 [
-    {
-        "id":
-            "4f32a8e1c6cf6e5885241f3ea5fee583560b2dfde38b21ec3f9781c91d58f42e",
-        "name": "my-module-1",
-        "version": "1.0.1",
-        "file": "my-module-1/main.css",
-        "content": "/* my-module-1/main.css */\n"
-    }
+  {
+    "id": "4f32a8e1c6cf6e5885241f3ea5fee583560b2dfde38b21ec3f9781c91d58f42e",
+    "name": "my-module-1",
+    "version": "1.0.1",
+    "file": "my-module-1/main.css",
+    "source": "/* my-module-1/main.css */\n"
+  }
 ]

--- a/test/test-assets/legacy.json
+++ b/test/test-assets/legacy.json
@@ -4,6 +4,6 @@
     "name": "my-module-1",
     "version": "1.0.1",
     "file": "my-module-1/main.css",
-    "source": "/* my-module-1/main.css */\n"
+    "content": "/* my-module-1/main.css */\n"
   }
 ]


### PR DESCRIPTION
## Status
**READY**

## Description
Changes .content to .source in feed definition. Does so in a backwards
compatible way so .content is still supported. This is because 'source' is the key used in js-reader and we want to be consistent between implementations.

## Todos
- [x] Tests
- [x] Documentation