### PR TITLE
feat: Add `minify` option like js-reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,11 @@ Supported arguments are:
 
 * `feeds` - Array - An Array of feeds.
 * `options` - Object - configuration.
-    * `options.minify` (default: false) Specify whether to minify code using uglify.
+    * `options.minify` (default: false) Specify whether to minify code using [cssnano](https://cssnano.co/).
 
-Returns: `Promise<string>` - A promise that resolves to a bundle string.
+Returns: `Promise<string>` - A promise that resolves to a bundle string that is processed by [autoprefixer](https://github.com/postcss/autoprefixer).
+
+Remember to specify a [browserslist](https://github.com/browserslist/browserslist) in your project to ensure cssnano and autoprefixer support the browsers your users use.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ Example
 const bundle = await cssReader([feed, ...feeds])
 ```
 
+This module has the following API:
+
+### function(feeds, [options])
+
+Supported arguments are:
+
+* `feeds` - Array - An Array of feeds.
+* `options` - Object - configuration.
+    * `options.minify` (default: false) Specify whether to minify code using uglify.
+
 Returns: `Promise<string>` - A promise that resolves to a bundle string.
 
 ## Contributing

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -2,8 +2,11 @@
 
 const assert = require('assert');
 const { EOL } = require('os');
+const postcss = require('postcss');
+const autoprefixer = require('autoprefixer');
+const cssnano = require('cssnano');
 
-module.exports = async function reader(feeds = []) {
+module.exports = async function reader(feeds = [], options = {}) {
     assert(
         feeds.length,
         `Expected at least 1 feed to be given. Instead got "${feeds.length}"`
@@ -15,6 +18,11 @@ module.exports = async function reader(feeds = []) {
 
     feeds = [].concat(...feeds);
 
+    const opts = {
+        minify: false,
+        ...options,
+    };
+
     const feedMap = new Map();
     feeds.forEach(feed => {
         // because feedMap preserves order, when we get a duplicate we actually
@@ -25,7 +33,17 @@ module.exports = async function reader(feeds = []) {
     });
 
     // backwards compatible refactor to `.source` from `.content`
-    return Array.from(feedMap.values())
+    const precss = Array.from(feedMap.values())
         .map(feed => (feed.source || feed.content).trim())
         .join(EOL + EOL);
+
+    const processor = postcss(autoprefixer());
+
+    if (opts.minify) {
+        processor.use(cssnano());
+    }
+
+    const { css } = await processor.process(precss, { map: false });
+
+    return css;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1465,6 +1465,11 @@
                 "defer-to-connect": "^1.0.1"
             }
         },
+        "@types/q": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
+            "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
+        },
         "JSONStream": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
@@ -1552,6 +1557,11 @@
                 "repeat-string": "^1.5.2"
             }
         },
+        "alphanum-sort": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+            "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
+        },
         "ambi": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/ambi/-/ambi-3.2.0.tgz",
@@ -1626,7 +1636,6 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
             "requires": {
                 "color-convert": "^1.9.0"
             }
@@ -1957,7 +1966,6 @@
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
             "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-            "dev": true,
             "requires": {
                 "sprintf-js": "~1.0.2"
             }
@@ -2104,6 +2112,60 @@
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
             "dev": true
+        },
+        "autoprefixer": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.1.tgz",
+            "integrity": "sha512-aVo5WxR3VyvyJxcJC3h4FKfwCQvQWb1tSI5VHNibddCVWrcD1NvlxEweg3TSgiPztMnWfjpy2FURKA2kvDE+Tw==",
+            "requires": {
+                "browserslist": "^4.6.3",
+                "caniuse-lite": "^1.0.30000980",
+                "chalk": "^2.4.2",
+                "normalize-range": "^0.1.2",
+                "num2fraction": "^1.2.2",
+                "postcss": "^7.0.17",
+                "postcss-value-parser": "^4.0.0"
+            },
+            "dependencies": {
+                "browserslist": {
+                    "version": "4.7.0",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
+                    "integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
+                    "requires": {
+                        "caniuse-lite": "^1.0.30000989",
+                        "electron-to-chromium": "^1.3.247",
+                        "node-releases": "^1.1.29"
+                    }
+                },
+                "caniuse-lite": {
+                    "version": "1.0.30000989",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
+                    "integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw=="
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "electron-to-chromium": {
+                    "version": "1.3.262",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.262.tgz",
+                    "integrity": "sha512-YFr53qZWr2pWkiTUorWEhAweujdf0ALiUp8VkNa0WGtbMVR+kZ8jNy3VTCemLsA4sT6+srCqehNn8TEAD0Ngrw=="
+                },
+                "node-releases": {
+                    "version": "1.1.32",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.32.tgz",
+                    "integrity": "sha512-VhVknkitq8dqtWoluagsGPn3dxTvN9fwgR59fV3D7sLBHe0JfDramsMI8n8mY//ccq/Kkrf8ZRHRpsyVZ3qw1A==",
+                    "requires": {
+                        "semver": "^5.3.0"
+                    }
+                }
+            }
         },
         "aws-sign2": {
             "version": "0.7.0",
@@ -2518,6 +2580,11 @@
             "integrity": "sha512-wI3QtdLppHNkmM1VgRVLCrlWCKk/YexlPicYbXPs4eYdd1InrUCTFsx5bX1iUQzzMsoRXXPpM1r+p7JEJJydag==",
             "dev": true
         },
+        "boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+        },
         "boom": {
             "version": "7.3.0",
             "resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
@@ -2635,7 +2702,6 @@
             "version": "4.3.6",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.6.tgz",
             "integrity": "sha512-kMGKs4BTzRWviZ8yru18xBpx+CyHG9eqgRbj9XbE3IMgtczf4aiA0Y1YCpVdvUieKGZ03kolSPXqTcscBCb9qw==",
-            "dev": true,
             "requires": {
                 "caniuse-lite": "^1.0.30000921",
                 "electron-to-chromium": "^1.3.92",
@@ -2736,7 +2802,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
             "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
-            "dev": true,
             "requires": {
                 "callsites": "^2.0.0"
             },
@@ -2744,8 +2809,7 @@
                 "callsites": {
                     "version": "2.0.0",
                     "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-                    "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-                    "dev": true
+                    "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
                 }
             }
         },
@@ -2790,11 +2854,21 @@
                 }
             }
         },
+        "caniuse-api": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+            "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
+            "requires": {
+                "browserslist": "^4.0.0",
+                "caniuse-lite": "^1.0.0",
+                "lodash.memoize": "^4.1.2",
+                "lodash.uniq": "^4.5.0"
+            }
+        },
         "caniuse-lite": {
             "version": "1.0.30000923",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000923.tgz",
-            "integrity": "sha512-j5ur7eeluOFjjPUkydtXP4KFAsmH3XaQNch5tvWSO+dLHYt5PE+VgJZLWtbVOodfWij6m6zas28T4gB/cLYq1w==",
-            "dev": true
+            "integrity": "sha512-j5ur7eeluOFjjPUkydtXP4KFAsmH3XaQNch5tvWSO+dLHYt5PE+VgJZLWtbVOodfWij6m6zas28T4gB/cLYq1w=="
         },
         "capture-exit": {
             "version": "1.2.0",
@@ -2889,7 +2963,6 @@
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-            "dev": true,
             "requires": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -3033,6 +3106,16 @@
             "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
             "dev": true
         },
+        "coa": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
+            "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
+            "requires": {
+                "@types/q": "^1.5.1",
+                "chalk": "^2.4.1",
+                "q": "^1.1.2"
+            }
+        },
         "code-point-at": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -3055,11 +3138,19 @@
                 "object-visit": "^1.0.0"
             }
         },
+        "color": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+            "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+            "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+            }
+        },
         "color-convert": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-            "dev": true,
             "requires": {
                 "color-name": "^1.1.1"
             }
@@ -3067,8 +3158,16 @@
         "color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "color-string": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+            "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+            "requires": {
+                "color-name": "^1.0.0",
+                "simple-swizzle": "^0.2.2"
+            }
         },
         "colors": {
             "version": "1.0.3",
@@ -3277,7 +3376,6 @@
             "version": "5.0.7",
             "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.7.tgz",
             "integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
-            "dev": true,
             "requires": {
                 "import-fresh": "^2.0.0",
                 "is-directory": "^0.3.1",
@@ -3289,7 +3387,6 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
                     "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-                    "dev": true,
                     "requires": {
                         "error-ex": "^1.3.1",
                         "json-parse-better-errors": "^1.0.1"
@@ -3362,6 +3459,155 @@
             "dev": true,
             "requires": {
                 "coffee-script": "^1.10.0"
+            }
+        },
+        "css-color-names": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+            "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
+        },
+        "css-declaration-sorter": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
+            "integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
+            "requires": {
+                "postcss": "^7.0.1",
+                "timsort": "^0.3.0"
+            }
+        },
+        "css-select": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
+            "integrity": "sha512-dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==",
+            "requires": {
+                "boolbase": "^1.0.0",
+                "css-what": "^2.1.2",
+                "domutils": "^1.7.0",
+                "nth-check": "^1.0.2"
+            }
+        },
+        "css-select-base-adapter": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
+            "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
+        },
+        "css-tree": {
+            "version": "1.0.0-alpha.33",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
+            "integrity": "sha512-SPt57bh5nQnpsTBsx/IXbO14sRc9xXu5MtMAVuo0BaQQmyf0NupNPPSoMaqiAF5tDFafYsTkfeH4Q/HCKXkg4w==",
+            "requires": {
+                "mdn-data": "2.0.4",
+                "source-map": "^0.5.3"
+            }
+        },
+        "css-unit-converter": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
+            "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY="
+        },
+        "css-what": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+            "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
+        },
+        "cssesc": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+            "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
+        },
+        "cssnano": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.10.tgz",
+            "integrity": "sha512-5wny+F6H4/8RgNlaqab4ktc3e0/blKutmq8yNlBFXA//nSFFAqAngjNVRzUvCgYROULmZZUoosL/KSoZo5aUaQ==",
+            "requires": {
+                "cosmiconfig": "^5.0.0",
+                "cssnano-preset-default": "^4.0.7",
+                "is-resolvable": "^1.0.0",
+                "postcss": "^7.0.0"
+            }
+        },
+        "cssnano-preset-default": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz",
+            "integrity": "sha512-x0YHHx2h6p0fCl1zY9L9roD7rnlltugGu7zXSKQx6k2rYw0Hi3IqxcoAGF7u9Q5w1nt7vK0ulxV8Lo+EvllGsA==",
+            "requires": {
+                "css-declaration-sorter": "^4.0.1",
+                "cssnano-util-raw-cache": "^4.0.1",
+                "postcss": "^7.0.0",
+                "postcss-calc": "^7.0.1",
+                "postcss-colormin": "^4.0.3",
+                "postcss-convert-values": "^4.0.1",
+                "postcss-discard-comments": "^4.0.2",
+                "postcss-discard-duplicates": "^4.0.2",
+                "postcss-discard-empty": "^4.0.1",
+                "postcss-discard-overridden": "^4.0.1",
+                "postcss-merge-longhand": "^4.0.11",
+                "postcss-merge-rules": "^4.0.3",
+                "postcss-minify-font-values": "^4.0.2",
+                "postcss-minify-gradients": "^4.0.2",
+                "postcss-minify-params": "^4.0.2",
+                "postcss-minify-selectors": "^4.0.2",
+                "postcss-normalize-charset": "^4.0.1",
+                "postcss-normalize-display-values": "^4.0.2",
+                "postcss-normalize-positions": "^4.0.2",
+                "postcss-normalize-repeat-style": "^4.0.2",
+                "postcss-normalize-string": "^4.0.2",
+                "postcss-normalize-timing-functions": "^4.0.2",
+                "postcss-normalize-unicode": "^4.0.1",
+                "postcss-normalize-url": "^4.0.1",
+                "postcss-normalize-whitespace": "^4.0.2",
+                "postcss-ordered-values": "^4.1.2",
+                "postcss-reduce-initial": "^4.0.3",
+                "postcss-reduce-transforms": "^4.0.2",
+                "postcss-svgo": "^4.0.2",
+                "postcss-unique-selectors": "^4.0.1"
+            }
+        },
+        "cssnano-util-get-arguments": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz",
+            "integrity": "sha1-7ToIKZ8h11dBsg87gfGU7UnMFQ8="
+        },
+        "cssnano-util-get-match": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cssnano-util-get-match/-/cssnano-util-get-match-4.0.0.tgz",
+            "integrity": "sha1-wOTKB/U4a7F+xeUiULT1lhNlFW0="
+        },
+        "cssnano-util-raw-cache": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/cssnano-util-raw-cache/-/cssnano-util-raw-cache-4.0.1.tgz",
+            "integrity": "sha512-qLuYtWK2b2Dy55I8ZX3ky1Z16WYsx544Q0UWViebptpwn/xDBmog2TLg4f+DBMg1rJ6JDWtn96WHbOKDWt1WQA==",
+            "requires": {
+                "postcss": "^7.0.0"
+            }
+        },
+        "cssnano-util-same-parent": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/cssnano-util-same-parent/-/cssnano-util-same-parent-4.0.1.tgz",
+            "integrity": "sha512-WcKx5OY+KoSIAxBW6UBBRay1U6vkYheCdjyVNDm85zt5K9mHoGOfsOsqIszfAqrQQFIIKgjh2+FDgIj/zsl21Q=="
+        },
+        "csso": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
+            "integrity": "sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==",
+            "requires": {
+                "css-tree": "1.0.0-alpha.29"
+            },
+            "dependencies": {
+                "css-tree": {
+                    "version": "1.0.0-alpha.29",
+                    "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
+                    "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
+                    "requires": {
+                        "mdn-data": "~1.1.0",
+                        "source-map": "^0.5.3"
+                    }
+                },
+                "mdn-data": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
+                    "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA=="
+                }
             }
         },
         "cssom": {
@@ -3537,7 +3783,6 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-            "dev": true,
             "requires": {
                 "object-keys": "^1.0.12"
             }
@@ -3678,6 +3923,27 @@
                 "esutils": "^2.0.2"
             }
         },
+        "dom-serializer": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz",
+            "integrity": "sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==",
+            "requires": {
+                "domelementtype": "^2.0.1",
+                "entities": "^2.0.0"
+            },
+            "dependencies": {
+                "domelementtype": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+                    "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+                }
+            }
+        },
+        "domelementtype": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+            "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+        },
         "domexception": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -3685,6 +3951,15 @@
             "dev": true,
             "requires": {
                 "webidl-conversions": "^4.0.2"
+            }
+        },
+        "domutils": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+            "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+            "requires": {
+                "dom-serializer": "0",
+                "domelementtype": "1"
             }
         },
         "dot-prop": {
@@ -3760,8 +4035,7 @@
         "electron-to-chromium": {
             "version": "1.3.95",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.95.tgz",
-            "integrity": "sha512-0JZEDKOQAE05EO/4rk3vLAE+PYFI9OLCVLAS4QAq1y+Bb2y1N6MyQJz62ynzHN/y0Ka/nO5jVJcahbCEdfiXLQ==",
-            "dev": true
+            "integrity": "sha512-0JZEDKOQAE05EO/4rk3vLAE+PYFI9OLCVLAS4QAq1y+Bb2y1N6MyQJz62ynzHN/y0Ka/nO5jVJcahbCEdfiXLQ=="
         },
         "elegant-spinner": {
             "version": "1.0.1",
@@ -3777,6 +4051,11 @@
             "requires": {
                 "once": "^1.4.0"
             }
+        },
+        "entities": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+            "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
         },
         "env-ci": {
             "version": "3.1.3",
@@ -3854,7 +4133,6 @@
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
             "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-            "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
             }
@@ -3863,7 +4141,6 @@
             "version": "1.12.0",
             "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
             "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
-            "dev": true,
             "requires": {
                 "es-to-primitive": "^1.1.1",
                 "function-bind": "^1.1.1",
@@ -3876,7 +4153,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
             "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-            "dev": true,
             "requires": {
                 "is-callable": "^1.1.4",
                 "is-date-object": "^1.0.1",
@@ -3901,8 +4177,7 @@
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "escodegen": {
             "version": "1.11.0",
@@ -4117,8 +4392,7 @@
         "esprima": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-            "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-            "dev": true
+            "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
         },
         "esquery": {
             "version": "1.0.1",
@@ -5467,8 +5741,7 @@
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "functional-red-black-tree": {
             "version": "1.0.1",
@@ -5745,7 +6018,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
             "requires": {
                 "function-bind": "^1.1.1"
             }
@@ -5762,14 +6034,12 @@
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "has-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-            "dev": true
+            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
         },
         "has-value": {
             "version": "1.0.0",
@@ -5831,6 +6101,11 @@
                 }
             }
         },
+        "hex-color-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
+            "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
+        },
         "hoek": {
             "version": "6.1.2",
             "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
@@ -5867,6 +6142,21 @@
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
             "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
             "dev": true
+        },
+        "hsl-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
+            "integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4="
+        },
+        "hsla-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
+            "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg="
+        },
+        "html-comment-regex": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
+            "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
         },
         "html-encoding-sniffer": {
             "version": "1.0.2",
@@ -5996,7 +6286,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
             "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
-            "dev": true,
             "requires": {
                 "caller-path": "^2.0.0",
                 "resolve-from": "^3.0.0"
@@ -6006,7 +6295,6 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
                     "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
-                    "dev": true,
                     "requires": {
                         "caller-callsite": "^2.0.0"
                     }
@@ -6014,8 +6302,7 @@
                 "resolve-from": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-                    "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-                    "dev": true
+                    "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
                 }
             }
         },
@@ -6074,6 +6361,11 @@
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
             "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
             "dev": true
+        },
+        "indexes-of": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+            "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
         },
         "inflight": {
             "version": "1.0.6",
@@ -6178,6 +6470,11 @@
             "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
             "dev": true
         },
+        "is-absolute-url": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+            "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY="
+        },
         "is-accessor-descriptor": {
             "version": "0.1.6",
             "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -6190,8 +6487,7 @@
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-            "dev": true
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
         },
         "is-buffer": {
             "version": "1.1.6",
@@ -6211,8 +6507,7 @@
         "is-callable": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-            "dev": true
+            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
         },
         "is-ci": {
             "version": "1.2.1",
@@ -6221,6 +6516,19 @@
             "dev": true,
             "requires": {
                 "ci-info": "^1.5.0"
+            }
+        },
+        "is-color-stop": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
+            "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
+            "requires": {
+                "css-color-names": "^0.0.4",
+                "hex-color-regex": "^1.1.0",
+                "hsl-regex": "^1.0.0",
+                "hsla-regex": "^1.0.0",
+                "rgb-regex": "^1.0.1",
+                "rgba-regex": "^1.0.0"
             }
         },
         "is-data-descriptor": {
@@ -6235,8 +6543,7 @@
         "is-date-object": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-            "dev": true
+            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
         },
         "is-descriptor": {
             "version": "0.1.6",
@@ -6260,8 +6567,7 @@
         "is-directory": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-            "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
-            "dev": true
+            "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
         },
         "is-dotfile": {
             "version": "1.0.3",
@@ -6351,8 +6657,7 @@
         "is-obj": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-            "dev": true
+            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
         },
         "is-observable": {
             "version": "1.1.0",
@@ -6438,7 +6743,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
             "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-            "dev": true,
             "requires": {
                 "has": "^1.0.1"
             }
@@ -6448,6 +6752,11 @@
             "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
             "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
             "dev": true
+        },
+        "is-resolvable": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+            "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
         },
         "is-retry-allowed": {
             "version": "1.1.0",
@@ -6467,11 +6776,18 @@
             "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
             "dev": true
         },
+        "is-svg": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
+            "integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
+            "requires": {
+                "html-comment-regex": "^1.1.0"
+            }
+        },
         "is-symbol": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
             "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-            "dev": true,
             "requires": {
                 "has-symbols": "^1.0.0"
             }
@@ -7114,7 +7430,6 @@
             "version": "3.10.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
             "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-            "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -7183,8 +7498,7 @@
         "json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-            "dev": true
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
         },
         "json-schema": {
             "version": "0.2.3",
@@ -7871,6 +8185,11 @@
             "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
             "dev": true
         },
+        "lodash.memoize": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+            "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+        },
         "lodash.pick": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
@@ -7898,8 +8217,7 @@
         "lodash.uniq": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-            "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
-            "dev": true
+            "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
         },
         "lodash.uniqby": {
             "version": "4.7.0",
@@ -8136,6 +8454,11 @@
             "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
             "dev": true
         },
+        "mdn-data": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+            "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
+        },
         "mem": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
@@ -8321,8 +8644,7 @@
         "minimist": {
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-            "dev": true
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minimist-options": {
             "version": "3.0.2",
@@ -8359,7 +8681,6 @@
             "version": "0.5.1",
             "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "dev": true,
             "requires": {
                 "minimist": "0.0.8"
             }
@@ -8503,7 +8824,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.2.tgz",
             "integrity": "sha512-j1gEV/zX821yxdWp/1vBMN0pSUjuH9oGUdLCb4PfUko6ZW7KdRs3Z+QGGwDUhYtSpQvdVVyLd2V0YvLsmdg5jQ==",
-            "dev": true,
             "requires": {
                 "semver": "^5.3.0"
             }
@@ -8529,11 +8849,15 @@
                 "remove-trailing-separator": "^1.0.1"
             }
         },
+        "normalize-range": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+            "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+        },
         "normalize-url": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-            "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
-            "dev": true
+            "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
         },
         "npm": {
             "version": "6.5.0",
@@ -11664,6 +11988,19 @@
                 "which": "^1.2.10"
             }
         },
+        "nth-check": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+            "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+            "requires": {
+                "boolbase": "~1.0.0"
+            }
+        },
+        "num2fraction": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+            "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
+        },
         "number-is-nan": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -11713,8 +12050,7 @@
         "object-keys": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-            "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
-            "dev": true
+            "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
         },
         "object-visit": {
             "version": "1.0.1",
@@ -11737,7 +12073,6 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
             "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-            "dev": true,
             "requires": {
                 "define-properties": "^1.1.2",
                 "es-abstract": "^1.5.1"
@@ -11768,6 +12103,17 @@
                     "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
                     "dev": true
                 }
+            }
+        },
+        "object.values": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+            "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.12.0",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3"
             }
         },
         "octokit-pagination-methods": {
@@ -12268,6 +12614,507 @@
             "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
             "dev": true
         },
+        "postcss": {
+            "version": "7.0.18",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.18.tgz",
+            "integrity": "sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==",
+            "requires": {
+                "chalk": "^2.4.2",
+                "source-map": "^0.6.1",
+                "supports-color": "^6.1.0"
+            },
+            "dependencies": {
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    },
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "5.5.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                            "requires": {
+                                "has-flag": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-calc": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.1.tgz",
+            "integrity": "sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==",
+            "requires": {
+                "css-unit-converter": "^1.1.1",
+                "postcss": "^7.0.5",
+                "postcss-selector-parser": "^5.0.0-rc.4",
+                "postcss-value-parser": "^3.3.1"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+                }
+            }
+        },
+        "postcss-colormin": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-4.0.3.tgz",
+            "integrity": "sha512-WyQFAdDZpExQh32j0U0feWisZ0dmOtPl44qYmJKkq9xFWY3p+4qnRzCHeNrkeRhwPHz9bQ3mo0/yVkaply0MNw==",
+            "requires": {
+                "browserslist": "^4.0.0",
+                "color": "^3.0.0",
+                "has": "^1.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+                }
+            }
+        },
+        "postcss-convert-values": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
+            "integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
+            "requires": {
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+                }
+            }
+        },
+        "postcss-discard-comments": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz",
+            "integrity": "sha512-RJutN259iuRf3IW7GZyLM5Sw4GLTOH8FmsXBnv8Ab/Tc2k4SR4qbV4DNbyyY4+Sjo362SyDmW2DQ7lBSChrpkg==",
+            "requires": {
+                "postcss": "^7.0.0"
+            }
+        },
+        "postcss-discard-duplicates": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
+            "integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
+            "requires": {
+                "postcss": "^7.0.0"
+            }
+        },
+        "postcss-discard-empty": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
+            "integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
+            "requires": {
+                "postcss": "^7.0.0"
+            }
+        },
+        "postcss-discard-overridden": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
+            "integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
+            "requires": {
+                "postcss": "^7.0.0"
+            }
+        },
+        "postcss-merge-longhand": {
+            "version": "4.0.11",
+            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz",
+            "integrity": "sha512-alx/zmoeXvJjp7L4mxEMjh8lxVlDFX1gqWHzaaQewwMZiVhLo42TEClKaeHbRf6J7j82ZOdTJ808RtN0ZOZwvw==",
+            "requires": {
+                "css-color-names": "0.0.4",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0",
+                "stylehacks": "^4.0.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+                }
+            }
+        },
+        "postcss-merge-rules": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz",
+            "integrity": "sha512-U7e3r1SbvYzO0Jr3UT/zKBVgYYyhAz0aitvGIYOYK5CPmkNih+WDSsS5tvPrJ8YMQYlEMvsZIiqmn7HdFUaeEQ==",
+            "requires": {
+                "browserslist": "^4.0.0",
+                "caniuse-api": "^3.0.0",
+                "cssnano-util-same-parent": "^4.0.0",
+                "postcss": "^7.0.0",
+                "postcss-selector-parser": "^3.0.0",
+                "vendors": "^1.0.0"
+            },
+            "dependencies": {
+                "dot-prop": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+                    "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+                    "requires": {
+                        "is-obj": "^1.0.0"
+                    }
+                },
+                "postcss-selector-parser": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+                    "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+                    "requires": {
+                        "dot-prop": "^4.1.1",
+                        "indexes-of": "^1.0.1",
+                        "uniq": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "postcss-minify-font-values": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
+            "integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
+            "requires": {
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+                }
+            }
+        },
+        "postcss-minify-gradients": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-4.0.2.tgz",
+            "integrity": "sha512-qKPfwlONdcf/AndP1U8SJ/uzIJtowHlMaSioKzebAXSG4iJthlWC9iSWznQcX4f66gIWX44RSA841HTHj3wK+Q==",
+            "requires": {
+                "cssnano-util-get-arguments": "^4.0.0",
+                "is-color-stop": "^1.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+                }
+            }
+        },
+        "postcss-minify-params": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-4.0.2.tgz",
+            "integrity": "sha512-G7eWyzEx0xL4/wiBBJxJOz48zAKV2WG3iZOqVhPet/9geefm/Px5uo1fzlHu+DOjT+m0Mmiz3jkQzVHe6wxAWg==",
+            "requires": {
+                "alphanum-sort": "^1.0.0",
+                "browserslist": "^4.0.0",
+                "cssnano-util-get-arguments": "^4.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0",
+                "uniqs": "^2.0.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+                }
+            }
+        },
+        "postcss-minify-selectors": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-4.0.2.tgz",
+            "integrity": "sha512-D5S1iViljXBj9kflQo4YutWnJmwm8VvIsU1GeXJGiG9j8CIg9zs4voPMdQDUmIxetUOh60VilsNzCiAFTOqu3g==",
+            "requires": {
+                "alphanum-sort": "^1.0.0",
+                "has": "^1.0.0",
+                "postcss": "^7.0.0",
+                "postcss-selector-parser": "^3.0.0"
+            },
+            "dependencies": {
+                "dot-prop": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+                    "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+                    "requires": {
+                        "is-obj": "^1.0.0"
+                    }
+                },
+                "postcss-selector-parser": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+                    "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+                    "requires": {
+                        "dot-prop": "^4.1.1",
+                        "indexes-of": "^1.0.1",
+                        "uniq": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "postcss-normalize-charset": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
+            "integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
+            "requires": {
+                "postcss": "^7.0.0"
+            }
+        },
+        "postcss-normalize-display-values": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.2.tgz",
+            "integrity": "sha512-3F2jcsaMW7+VtRMAqf/3m4cPFhPD3EFRgNs18u+k3lTJJlVe7d0YPO+bnwqo2xg8YiRpDXJI2u8A0wqJxMsQuQ==",
+            "requires": {
+                "cssnano-util-get-match": "^4.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+                }
+            }
+        },
+        "postcss-normalize-positions": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-4.0.2.tgz",
+            "integrity": "sha512-Dlf3/9AxpxE+NF1fJxYDeggi5WwV35MXGFnnoccP/9qDtFrTArZ0D0R+iKcg5WsUd8nUYMIl8yXDCtcrT8JrdA==",
+            "requires": {
+                "cssnano-util-get-arguments": "^4.0.0",
+                "has": "^1.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+                }
+            }
+        },
+        "postcss-normalize-repeat-style": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.2.tgz",
+            "integrity": "sha512-qvigdYYMpSuoFs3Is/f5nHdRLJN/ITA7huIoCyqqENJe9PvPmLhNLMu7QTjPdtnVf6OcYYO5SHonx4+fbJE1+Q==",
+            "requires": {
+                "cssnano-util-get-arguments": "^4.0.0",
+                "cssnano-util-get-match": "^4.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+                }
+            }
+        },
+        "postcss-normalize-string": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-4.0.2.tgz",
+            "integrity": "sha512-RrERod97Dnwqq49WNz8qo66ps0swYZDSb6rM57kN2J+aoyEAJfZ6bMx0sx/F9TIEX0xthPGCmeyiam/jXif0eA==",
+            "requires": {
+                "has": "^1.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+                }
+            }
+        },
+        "postcss-normalize-timing-functions": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.2.tgz",
+            "integrity": "sha512-acwJY95edP762e++00Ehq9L4sZCEcOPyaHwoaFOhIwWCDfik6YvqsYNxckee65JHLKzuNSSmAdxwD2Cud1Z54A==",
+            "requires": {
+                "cssnano-util-get-match": "^4.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+                }
+            }
+        },
+        "postcss-normalize-unicode": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
+            "integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
+            "requires": {
+                "browserslist": "^4.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+                }
+            }
+        },
+        "postcss-normalize-url": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
+            "integrity": "sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==",
+            "requires": {
+                "is-absolute-url": "^2.0.0",
+                "normalize-url": "^3.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+                }
+            }
+        },
+        "postcss-normalize-whitespace": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.2.tgz",
+            "integrity": "sha512-tO8QIgrsI3p95r8fyqKV+ufKlSHh9hMJqACqbv2XknufqEDhDvbguXGBBqxw9nsQoXWf0qOqppziKJKHMD4GtA==",
+            "requires": {
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+                }
+            }
+        },
+        "postcss-ordered-values": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-4.1.2.tgz",
+            "integrity": "sha512-2fCObh5UanxvSxeXrtLtlwVThBvHn6MQcu4ksNT2tsaV2Fg76R2CV98W7wNSlX+5/pFwEyaDwKLLoEV7uRybAw==",
+            "requires": {
+                "cssnano-util-get-arguments": "^4.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+                }
+            }
+        },
+        "postcss-reduce-initial": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
+            "integrity": "sha512-gKWmR5aUulSjbzOfD9AlJiHCGH6AEVLaM0AV+aSioxUDd16qXP1PCh8d1/BGVvpdWn8k/HiK7n6TjeoXN1F7DA==",
+            "requires": {
+                "browserslist": "^4.0.0",
+                "caniuse-api": "^3.0.0",
+                "has": "^1.0.0",
+                "postcss": "^7.0.0"
+            }
+        },
+        "postcss-reduce-transforms": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.2.tgz",
+            "integrity": "sha512-EEVig1Q2QJ4ELpJXMZR8Vt5DQx8/mo+dGWSR7vWXqcob2gQLyQGsionYcGKATXvQzMPn6DSN1vTN7yFximdIAg==",
+            "requires": {
+                "cssnano-util-get-match": "^4.0.0",
+                "has": "^1.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+                }
+            }
+        },
+        "postcss-selector-parser": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+            "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+            "requires": {
+                "cssesc": "^2.0.0",
+                "indexes-of": "^1.0.1",
+                "uniq": "^1.0.1"
+            }
+        },
+        "postcss-svgo": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.2.tgz",
+            "integrity": "sha512-C6wyjo3VwFm0QgBy+Fu7gCYOkCmgmClghO+pjcxvrcBKtiKt0uCF+hvbMO1fyv5BMImRK90SMb+dwUnfbGd+jw==",
+            "requires": {
+                "is-svg": "^3.0.0",
+                "postcss": "^7.0.0",
+                "postcss-value-parser": "^3.0.0",
+                "svgo": "^1.0.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+                }
+            }
+        },
+        "postcss-unique-selectors": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
+            "integrity": "sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==",
+            "requires": {
+                "alphanum-sort": "^1.0.0",
+                "postcss": "^7.0.0",
+                "uniqs": "^2.0.0"
+            }
+        },
+        "postcss-value-parser": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+            "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ=="
+        },
         "prelude-ls": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -12393,8 +13240,7 @@
         "q": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-            "dev": true
+            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
         },
         "qs": {
             "version": "6.5.2",
@@ -12892,6 +13738,16 @@
             "integrity": "sha512-GFN9gTsQxHSs4PitqsnYO036weay+K7f2gQ3yj5KilKkeZhEDugAKvak1AyMfdae/LlgjcgZjPxL0inPEXueRA==",
             "dev": true
         },
+        "rgb-regex": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
+            "integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE="
+        },
+        "rgba-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
+            "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
+        },
         "right-align": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -13297,8 +14153,7 @@
         "sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-            "dev": true
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
         "semantic-release": {
             "version": "15.13.1",
@@ -13671,8 +14526,7 @@
         "semver": {
             "version": "5.4.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-            "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-            "dev": true
+            "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
         },
         "semver-compare": {
             "version": "1.0.0",
@@ -13845,6 +14699,21 @@
                 }
             }
         },
+        "simple-swizzle": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+            "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+            "requires": {
+                "is-arrayish": "^0.3.1"
+            },
+            "dependencies": {
+                "is-arrayish": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+                    "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+                }
+            }
+        },
         "sisteransi": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz",
@@ -13996,8 +14865,7 @@
         "source-map": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-            "dev": true
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "source-map-resolve": {
             "version": "0.5.2",
@@ -14106,8 +14974,7 @@
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-            "dev": true
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
         "sshpk": {
             "version": "1.15.2",
@@ -14125,6 +14992,11 @@
                 "safer-buffer": "^2.0.2",
                 "tweetnacl": "~0.14.0"
             }
+        },
+        "stable": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+            "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
         },
         "stack-utils": {
             "version": "1.0.2",
@@ -14275,13 +15147,73 @@
             "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
             "dev": true
         },
+        "stylehacks": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
+            "integrity": "sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==",
+            "requires": {
+                "browserslist": "^4.0.0",
+                "postcss": "^7.0.0",
+                "postcss-selector-parser": "^3.0.0"
+            },
+            "dependencies": {
+                "dot-prop": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+                    "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+                    "requires": {
+                        "is-obj": "^1.0.0"
+                    }
+                },
+                "postcss-selector-parser": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+                    "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+                    "requires": {
+                        "dot-prop": "^4.1.1",
+                        "indexes-of": "^1.0.1",
+                        "uniq": "^1.0.1"
+                    }
+                }
+            }
+        },
         "supports-color": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
             "requires": {
                 "has-flag": "^3.0.0"
+            }
+        },
+        "svgo": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz",
+            "integrity": "sha512-MLfUA6O+qauLDbym+mMZgtXCGRfIxyQoeH6IKVcFslyODEe/ElJNwr0FohQ3xG4C6HK6bk3KYPPXwHVJk3V5NQ==",
+            "requires": {
+                "chalk": "^2.4.1",
+                "coa": "^2.0.2",
+                "css-select": "^2.0.0",
+                "css-select-base-adapter": "^0.1.1",
+                "css-tree": "1.0.0-alpha.33",
+                "csso": "^3.5.1",
+                "js-yaml": "^3.13.1",
+                "mkdirp": "~0.5.1",
+                "object.values": "^1.1.0",
+                "sax": "~1.2.4",
+                "stable": "^0.1.8",
+                "unquote": "~1.1.1",
+                "util.promisify": "~1.0.0"
+            },
+            "dependencies": {
+                "js-yaml": {
+                    "version": "3.13.1",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+                    "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+                    "requires": {
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
+                    }
+                }
             }
         },
         "symbol-observable": {
@@ -14489,6 +15421,11 @@
             "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
             "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
             "dev": true
+        },
+        "timsort": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
+            "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
         },
         "tmp": {
             "version": "0.0.33",
@@ -14946,6 +15883,16 @@
                 }
             }
         },
+        "uniq": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+            "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+        },
+        "uniqs": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+            "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
+        },
         "unique-string": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
@@ -14969,6 +15916,11 @@
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
             "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
             "dev": true
+        },
+        "unquote": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+            "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
         },
         "unset-value": {
             "version": "1.0.0",
@@ -15092,7 +16044,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
             "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-            "dev": true,
             "requires": {
                 "define-properties": "^1.1.2",
                 "object.getownpropertydescriptors": "^2.0.3"
@@ -15113,6 +16064,11 @@
                 "spdx-correct": "~1.0.0",
                 "spdx-expression-parse": "~1.0.0"
             }
+        },
+        "vendors": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.3.tgz",
+            "integrity": "sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw=="
         },
         "verror": {
             "version": "1.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1545,6 +1545,7 @@
             "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "kind-of": "^3.0.2",
                 "longest": "^1.0.1",
@@ -4935,7 +4936,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -4956,12 +4958,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -4976,17 +4980,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -5103,7 +5110,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -5115,6 +5123,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -5129,6 +5138,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -5136,12 +5146,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.2.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.1",
                         "yallist": "^3.0.0"
@@ -5160,6 +5172,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -5240,7 +5253,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -5252,6 +5266,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -5337,7 +5352,8 @@
                 "safe-buffer": {
                     "version": "5.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -5373,6 +5389,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -5392,6 +5409,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -5435,12 +5453,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,11 @@
     "greenkeeper[bot] (http://github.com/apps/greenkeeper)"
   ],
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "autoprefixer": "^9.6.1",
+    "cssnano": "^4.1.10",
+    "postcss": "^7.0.18"
+  },
   "devDependencies": {
     "@asset-pipe/sink-fs": "^1.1.4",
     "commitizen": "^3.0.5",

--- a/test/__snapshots__/reader.test.js.snap
+++ b/test/__snapshots__/reader.test.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Autoprefixer removes old CSS syntax 1`] = `
+".example {
+    border-radius: 2px;
+}
+
+.example {
+    border-radius: 2px;
+}"
+`;
+
 exports[`Dedupe of identical hashes occurs 1`] = `"/* my-module-1/main.css */"`;
 
 exports[`reader(): throws on no input 1`] = `"Expected at least 1 feed to be given. Instead got \\"0\\""`;

--- a/test/reader.test.js
+++ b/test/reader.test.js
@@ -113,3 +113,27 @@ test('reader([s1,s2,s3,s4]) ensure dedupe and correct css concat order', async (
         '/* my-module-1/main.css */',
     ]);
 });
+
+test('Autoprefixer removes old CSS syntax', async () => {
+    expect.assertions(1);
+    const sink = new SinkFs({
+        path: path.join(__dirname, './test-assets'),
+    });
+    const feed = JSON.parse(await sink.get('e.json'));
+
+    const result = await reader([feed]);
+
+    expect(result).not.toMatch('-webkit-border-radius');
+});
+
+test('cssnano dedupes and minifies', async () => {
+    expect.assertions(1);
+    const sink = new SinkFs({
+        path: path.join(__dirname, './test-assets'),
+    });
+    const feed = JSON.parse(await sink.get('e.json'));
+
+    const result = await reader([feed], { minify: true });
+
+    expect(result).toBe('.example{border-radius:2px}');
+});

--- a/test/reader.test.js
+++ b/test/reader.test.js
@@ -115,7 +115,7 @@ test('reader([s1,s2,s3,s4]) ensure dedupe and correct css concat order', async (
 });
 
 test('Autoprefixer removes old CSS syntax', async () => {
-    expect.assertions(1);
+    expect.assertions(2);
     const sink = new SinkFs({
         path: path.join(__dirname, './test-assets'),
     });
@@ -124,6 +124,7 @@ test('Autoprefixer removes old CSS syntax', async () => {
     const result = await reader([feed]);
 
     expect(result).not.toMatch('-webkit-border-radius');
+    expect(result).toMatchSnapshot();
 });
 
 test('cssnano dedupes and minifies', async () => {

--- a/test/test-assets/e.json
+++ b/test/test-assets/e.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "ac0ee854d0ad3c1d55bdfec6f88b5a2e5c46dbcafb26401c4ff4465c8a42b093",
+    "name": "my-module-1",
+    "version": "1.0.1",
+    "file": "my-module-1/main.css",
+    "source": ".example {\n    -webkit-border-radius: 2px;\n    border-radius: 2px;\n}"
+  },
+  {
+    "id": "4da2d72bade347dc63aa34a30d533e211e6ea593ff996bf92b6f17a1e4608190",
+    "name": "my-module-2",
+    "version": "1.0.1",
+    "file": "my-module-2/css/main.css",
+    "source": ".example {\n    border-radius: 2px;\n}"
+  }
+]


### PR DESCRIPTION
This PR implements [cssnano](https://cssnano.co/) when `minify` is true, mirroring the js-reader API.

[Autoprefixer](https://github.com/postcss/autoprefixer) is added as a layer similar to core-js to ensure both that older browsers aren't left behind because a prefix were forgotten about, nor that modern browsers pay for old legacy CSS full of vendor prefixes that isn't needed anymore at all. Because of that it's not toggled by the `minify` option, as that option does not change the behavior of the CSS, only the amount of CSS over the wire.